### PR TITLE
Prevent connection updates

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -27,13 +27,6 @@ paths:
       responses:
         '200':
           description: Success
-    put:
-      tags:
-        - connection
-      summary: Replaces the current connection profile
-      responses:
-        '200':
-          description: Success
   /transactions:
     get:
       tags:


### PR DESCRIPTION
The connection profile will be configured when the server startes instead, but it’s probably still useful to be able to get a copy via the REST API

Signed-off-by: James Taylor <jamest@uk.ibm.com>